### PR TITLE
Use html dir attribute instead of css direction attribute

### DIFF
--- a/src/directionediting.js
+++ b/src/directionediting.js
@@ -63,10 +63,8 @@ function _buildDefinition( options ) {
 
 	for ( const option of options ) {
 		definition.view[ option ] = {
-			key: 'style',
-			value: {
-				'direction': option
-			}
+			key: 'dir',
+			value: option
 		};
 	}
 


### PR DESCRIPTION
As per <https://www.w3.org/International/questions/qa-bidi-css-markup>
this should be used the default and this also allows for easier CSS
selection.